### PR TITLE
fix .gitsubmodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "trans-frontend"]
 	path = trans-frontend
-	url = git@github.com:trans-itf/trans-frontend
+	url = https://github.com/trans-itf/trans-frontend
 [submodule "trans-backend"]
 	path = trans-backend
-	url = git@github.com:trans-itf/trans-backend
+	url = https://github.com/trans-itf/trans-backend


### PR DESCRIPTION
.gitsubmodulesのURLをSSH URLからHTTPS URLに変更